### PR TITLE
Use trivial-garbage to provide weak hash tables.

### DIFF
--- a/cl-hooks.asd
+++ b/cl-hooks.asd
@@ -24,7 +24,8 @@
 mechanism (as known, e.g., from GNU Emacs)."
   :depends-on  (:alexandria
 		:let-plus
-		:closer-mop)
+		:closer-mop
+		:trivial-garbage)
   :components  ((:module     "src/early"
 		 :pathname   "src"
 		 :serial     t

--- a/src/object-external.lisp
+++ b/src/object-external.lisp
@@ -42,6 +42,6 @@ objects."))
 (defmethod external-hook ((object t) (hook symbol))
   (let ((table (or (get hook 'external-hook-objects)
 		   (setf (get hook 'external-hook-objects)
-			 (make-hash-table :test #'eq :weakness :key)))))
+		         (trivial-garbage:make-weak-hash-table :test #'eq :weakness :key)))))
     (ensure-gethash object table (make-instance 'external-hook
 						:name hook))))

--- a/src/object-internal.lisp
+++ b/src/object-internal.lisp
@@ -75,7 +75,7 @@ name HOOK."))
 (defmethod object-hook ((object standard-object) (hook symbol))
   (let ((table (or (get hook 'hook-objects)
 		   (setf (get hook 'hook-objects)
-			 (make-hash-table :test #'eq :weakness :key)))))
+		         (trivial-garbage:make-weak-hash-table :test #'eq :weakness :key)))))
     (or (nth-value 0 (gethash object table))
 	(setf (gethash object table)
 	      (progn


### PR DESCRIPTION
Added a dependency on trivial-garbage to portably support weak hash tables. Tests pass on SBCL 1.1.15 and Allegro 9.0.
